### PR TITLE
Support listing of all records

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,13 @@
 import express, { Application, Request, Response } from 'express';
 import { config } from 'dotenv';
 import sdk from 'aws-sdk';
-import { uniqueID } from './src/helpers';
+import { uniqueID, pprint } from './src/helpers';
 const { QLDB } = sdk;
 
 import { DOC_TABLE_NAME } from './src/qldb-Constants.js';
 import { listLedgers } from './src/qldb-ListLedgers';
 import { insertDocuments } from './src/qldb-InsertDocument';
+import { listDocuments } from './src/qldb-ListDocuments';
 
 import { RecordSchema } from './src/schemas';
 
@@ -31,7 +32,15 @@ app.get(
   async (req: Request, res: Response): Promise<Response> => {
     const qldbClient = new QLDB();
     const result = await listLedgers(qldbClient);
-    return res.status(200).send(result);
+    return res.status(200).send(pprint(result));
+  }
+);
+
+app.get(
+  '/list-docs',
+  async (req: Request, res: Response): Promise<Response> => {
+    const result = await listDocuments(DOC_TABLE_NAME);
+    return res.status(200).send(pprint(result));
   }
 );
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,3 +6,9 @@ import { nanoid } from 'nanoid';
  * @returns A unique string
  */
 export const uniqueID = (): string => nanoid();
+
+/**
+ * Pretty prints a JSON var
+ * @returns A nicely-formatted string
+ */
+export const pprint = (json: {}): string => JSON.stringify(json, null, 4);

--- a/src/qldb-ListDocuments.ts
+++ b/src/qldb-ListDocuments.ts
@@ -1,0 +1,27 @@
+import {
+  QldbDriver,
+  Result,
+  TransactionExecutor,
+} from 'amazon-qldb-driver-nodejs';
+import { getQldbDriver } from './qldb-ConnectToLedger';
+
+/**
+ * List all documents in a given table.
+ * @param tableName Name of the table to look up documents from.
+ * @returns Promise which fulfills with a {@linkcode Result} object.
+ */
+export const listDocuments = async function (
+  tableName: string
+): Promise<Result> {
+  try {
+    const qldbDriver: QldbDriver = getQldbDriver();
+    const statement: string = `SELECT * FROM ${tableName}`;
+    let r = qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
+      let results = await txn.execute(statement);
+      return results;
+    });
+    return r;
+  } catch (e) {
+    console.log(`Unable to list documents in ${tableName}: ${e}`);
+  }
+};


### PR DESCRIPTION
This PR implements the listing of all records in a QLDB table.

`index.ts` includes a new route chosen on a GET request to `/list-docs`.

It consumes a request of this type:

```
$ curl http://localhost:3000/list-docs
```