### PR TITLE
Sort Bundle alphabetically to preserve identity. Fixes #16

### DIFF
--- a/src/types/Bundle.ts
+++ b/src/types/Bundle.ts
@@ -14,9 +14,19 @@ export type Bundle = File.File[];
 export type newBundle = Array<File.newFile>;
 
 /**
+ * Ensure the bundle (a list of files) is _always_ sorted
+ * the same way to preserve identity.
+ * @param b a Bundle
+ * @returns a Bundle, sorted alphabetically by its ID
+ */
+const sortedBundle = (b: Bundle): Bundle =>
+  b.sort((a, b) => File.id(a).localeCompare(File.id(b)));
+
+/**
  * A bundle's ID is the sum of its composing parts' IDs (or hashes)
  * @param b a Bundle
  * @returns a string
  */
 // @TODO: confirm this is accurate
-export const id = (b: Bundle): string => makeHash(b.map(File.id).join(''));
+export const id = (b: Bundle): string =>
+  makeHash(sortedBundle(b).map(File.id).join(''));

--- a/src/types/Bundle.ts
+++ b/src/types/Bundle.ts
@@ -19,8 +19,10 @@ export type newBundle = Array<File.newFile>;
  * @param b a Bundle
  * @returns a Bundle, sorted alphabetically by its ID
  */
-const sortedBundle = (b: Bundle): Bundle =>
-  b.sort((a, b) => File.id(a).localeCompare(File.id(b)));
+const sortedBundle = (b: Bundle): Bundle => {
+  const sortedArray = [...b].sort((a, b) => File.id(a).localeCompare(File.id(b)));
+  return sortedArray;
+}
 
 /**
  * A bundle's ID is the sum of its composing parts' IDs (or hashes)


### PR DESCRIPTION
**PR #15 is blocked until this issue is resolved**

The issue is the preservation of the identity of a bundle. 

Since the bundle's identity directly derives from the concatenation of its children's IDs, the order of these children is crucial.

We get around this problem by sorting prior to concatenating, and that is hopefully the end of that.

---

I've tested it by adding a new record to the ledger:

```
    {
        "title": "About Our Team | Berkeley Advanced Media Institute",
        "sku": "f64afba54593de60b5208067a0d75836b9451c1162581ab09bf960c631ea3be9",
        "url": "https://multimedia.journalism.berkeley.edu/about-berkeley-advanced-media-institute/",
        "thumb": "3d59f33aad957797c84a035cf80a5b05f14d8c47e8105ddff42d5bce0ef3fd4a",
        "hash": "6e0fcccd9b07c96a7594b5f877a4a52f3946e146e44f612d3e1ab6c914ab31a5"
    }
```

The string passed to `makeHash()` (our handler returning a string's SHA256) is `3d59f33aad957797c84a035cf80a5b05f14d8c47e8105ddff42d5bce0ef3fd4a6e0fcccd9b07c96a7594b5f877a4a52f3946e146e44f612d3e1ab6c914ab31a5`, and the resulting SHA256 is `f64afba54593de60b5208067a0d75836b9451c1162581ab09bf960c631ea3be9`, i.e. the `sku: ` value.