### PR TITLE
Implement one-file archiving 

### DIFF
--- a/gui/src/LedgerEntry.svelte
+++ b/gui/src/LedgerEntry.svelte
@@ -48,5 +48,8 @@
     <pre>🔗 {entry.url}</pre>
     <pre>🔖 {entry.sku}</pre>
     <pre>⚙️ {entry.hash}</pre>
+    {#if entry.one_file}
+      <pre>📁 {entry.one_file}</pre>
+    {/if}
   </div>
 </section>

--- a/gui/src/LedgerEntry.svelte
+++ b/gui/src/LedgerEntry.svelte
@@ -39,17 +39,17 @@
 
 <section>
   <div class="thumbnail">
-    {#if entry.hash}
-      <img src={pathToThumbnail(entry.thumb)} alt="" />
+    {#if entry.thumb_hash}
+      <img src={pathToThumbnail(entry.thumb_hash)} alt="" />
     {/if}
   </div>
   <div class="metadata">
     <h4>📦 • {entry.title}</h4>
     <pre>🔗 {entry.url}</pre>
     <pre>🔖 {entry.sku}</pre>
-    <pre>⚙️ {entry.hash}</pre>
-    {#if entry.one_file}
-      <pre>📁 {entry.one_file}</pre>
+    <pre>📷️ {entry.screenshot_hash}</pre>
+    {#if entry.one_file_hash}
+      <pre>📁 {entry.one_file_hash}</pre>
     {/if}
   </div>
 </section>

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -2,6 +2,7 @@ export type LedgerEntry = {
   title: string;
   url: string;
   sku: string;
-  hash?: string;
-  thumb?: string;
+  screenshot_hash?: string;
+  thumb_hash?: string;
+  one_file_hash?: string;
 };

--- a/index.ts
+++ b/index.ts
@@ -59,6 +59,7 @@ app.post('/form', async (req: Request, res: Response): Promise<Response> => {
 
   form.parse(req, async (err: any, fields: Fields): Promise<void> => {
     let base64Data: string;
+    let onefileData: string;
     //@ts-expect-error
     base64Data = fields.scr.replace(/^data:image\/png;base64,/, '');
     base64Data += base64Data.replace('+', ' ');
@@ -66,14 +67,16 @@ app.post('/form', async (req: Request, res: Response): Promise<Response> => {
     const thumbnailData = await sharp(screenshotData)
       .resize(320, 240, { fit: 'inside' })
       .toBuffer();
+    onefileData = fields.onefile as string;
 
     const { url, title } = fields;
-    const file = { kind: 'screenshot' as const, data: screenshotData };
+    const screenshot = { kind: 'screenshot' as const, data: screenshotData };
     const thumbnail = {
       kind: 'screenshot_thumbnail' as const,
       data: thumbnailData,
     };
-    Store.newBundle([file, thumbnail]).then(b => {
+    const onefile = { kind: 'one_file' as const, data: onefileData };
+    Store.newBundle([screenshot, thumbnail, onefile]).then(b => {
       const document = {
         bundle: b,
         annotations: { description: '' },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
       "email": "niko@niko.io"
     }
   ],
-  "version": "2.1.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@types/formidable": "^1.2.2",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,11 +15,11 @@ const config = {
 
 /**
  * Promise to write a buffer to a path
- * @param b a buffer
+ * @param b a buffer if file is an image ; a string of HTML code if file is a page
  * @param path string
  * @returns A resolved promise
  */
-const writeToDisk = (b: Buffer, path: string): Promise<void> =>
+const writeToDisk = (b: Buffer | string, path: string): Promise<void> =>
   new Promise((resolve, reject) =>
     fs.writeFile(path, b, err => {
       if (err) reject(err);
@@ -29,7 +29,7 @@ const writeToDisk = (b: Buffer, path: string): Promise<void> =>
 
 /**
  * Logic for saving a file to disk from a storage config object
- * @param a a newFile, made of a buffer
+ * @param a a newFile, made of a buffer or of a string of HTML code
  * @returns a promise of a File, having been written to disk
  **/
 export const writeOne = async (a: File.newFile): Promise<File.File> => {
@@ -38,7 +38,8 @@ export const writeOne = async (a: File.newFile): Promise<File.File> => {
     throw new Error(`No directory set in config`);
   }
   const name = makeHash(a.data);
-  const path = `${dir}/${name}.png`;
+  const format = a.kind === 'one_file' ? 'html' : 'png';
+  const path = `${dir}/${name}.${format}`;
   await writeToDisk(a.data, path);
   return { kind: a.kind, hash: name };
 };

--- a/src/types/File.ts
+++ b/src/types/File.ts
@@ -1,10 +1,10 @@
 type Hash = string;
 
-export type Process = 'screenshot' | '1file' | 'screenshot_thumbnail';
+export type Process = 'screenshot' | 'one_file' | 'screenshot_thumbnail';
 
 export type File = { kind: Process; hash: Hash };
 
-export type newFile = { kind: Process; data: Buffer };
+export type newFile = { kind: Process; data: Buffer | string };
 
 /**
  * A File's ID is its hash

--- a/src/types/Record.ts
+++ b/src/types/Record.ts
@@ -15,6 +15,7 @@ export type FrontEndRecord = {
   url: string;
   thumb?: string;
   hash?: string;
+  one_file?: string;
 };
 
 const DocSchema = yup
@@ -71,6 +72,7 @@ export const fromLedger = (o: ArbitraryObject): Record => {
         kind: 'screenshot_thumbnail' as const,
         hash: o?.screenshot_thumbnail,
       },
+      { kind: 'one_file' as const, hash: o?.one_file },
     ],
   };
   console.warn(` got this junk from the ledger: ${o}`);
@@ -87,4 +89,5 @@ export const toFrontend = (r: Record): FrontEndRecord => ({
   url: r.data.url,
   thumb: r.bundle.find(f => f.kind === 'screenshot_thumbnail')?.hash,
   hash: r.bundle.find(f => f.kind === 'screenshot')?.hash,
+  one_file: r.bundle.find(f => f.kind === 'one_file')?.hash,
 });

--- a/src/types/Record.ts
+++ b/src/types/Record.ts
@@ -13,9 +13,9 @@ export type FrontEndRecord = {
   title: string;
   sku: string;
   url: string;
-  thumb?: string;
-  hash?: string;
-  one_file?: string;
+  thumb_hash?: string;
+  screenshot_hash?: string;
+  one_file_hash?: string;
 };
 
 const DocSchema = yup
@@ -87,7 +87,7 @@ export const toFrontend = (r: Record): FrontEndRecord => ({
   title: r.data.title,
   sku: id(r),
   url: r.data.url,
-  thumb: r.bundle.find(f => f.kind === 'screenshot_thumbnail')?.hash,
-  hash: r.bundle.find(f => f.kind === 'screenshot')?.hash,
-  one_file: r.bundle.find(f => f.kind === 'one_file')?.hash,
+  thumb_hash: r.bundle.find(f => f.kind === 'screenshot_thumbnail')?.hash,
+  screenshot_hash: r.bundle.find(f => f.kind === 'screenshot')?.hash,
+  one_file_hash: r.bundle.find(f => f.kind === 'one_file')?.hash,
 });


### PR DESCRIPTION
Another field comes in to the `POST /form` endpoint, containing a (long) string of HTML (with inlined styles, JS, and encoded images).

As part of the Bundle, this string is saved to disk as an HTML file, and its hash is preserved in the ledger.